### PR TITLE
Expose the load averages when calling SysInfo

### DIFF
--- a/facts.go
+++ b/facts.go
@@ -31,8 +31,16 @@ type SystemFacts struct {
 	OSRelease    OSRelease
 	Swap         Swap
 	Uptime       int64
+	LoadAverage  LoadAverage
 
 	mu sync.Mutex
+}
+
+// Holds the load average facts.
+type LoadAverage struct {
+	One  uint64
+	Five uint64
+	Ten  uint64
 }
 
 // Date holds the date facts.
@@ -143,6 +151,10 @@ func (f *SystemFacts) getSysInfo(wg *sync.WaitGroup) {
 	f.Swap.Free = info.Freeswap
 
 	f.Uptime = info.Uptime
+
+	f.LoadAverage.One = info.Loads[0]
+	f.LoadAverage.Five = info.Loads[1]
+	f.LoadAverage.Ten = info.Loads[2]
 
 	return
 }


### PR DESCRIPTION
Adds a new `LoadAverage` struct that holds the one, five and ten minute
load averages for the machine. The values are read from the
`unix.Sysinfo_t` struct that's already loaded as part of the
`getSysInfo()` function.
