### PR TITLE
More idiomatic JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,69 +30,69 @@ terminus
 ```
 ```
 {
-   "System": {
-     "Architecture": "x86_64",
-     "BootID": "e9e1695b-4c87-40fe-b701-d19dc262fc25",
-     "Date": {
-       "Unix": 1428781730,
+   "system": {
+     "architecture": "x86_64",
+     "bootID": "e9e1695b-4c87-40fe-b701-d19dc262fc25",
+     "date": {
+       "unix": 1428781730,
        "UTC": "2015-04-11 19:48:50.291769492 +0000 UTC"
      },
-     "Domainname": "(none)",
-     "Hostname": "ubuntu",
-     "Network": {
-       "Interfaces": {
+     "domainName": "(none)",
+     "hostName": "ubuntu",
+     "network": {
+       "interfaces": {
          "docker0": {
-           "Name": "docker0",
-           "Index": 3,
-           "HardwareAddr": "56:84:7a:fe:97:99",
-           "IpAddresses": [
+           "name": "docker0",
+           "index": 3,
+           "hardwareAddr": "56:84:7a:fe:97:99",
+           "ipAddresses": [
              "172.17.42.1/16"
            ]
          },
          "eth0": {
-           "Name": "eth0",
-           "Index": 2,
-           "HardwareAddr": "00:0c:29:ca:67:76",
-           "IpAddresses": [
+           "name": "eth0",
+           "index": 2,
+           "hardwareAddr": "00:0c:29:ca:67:76",
+           "ipAddresses": [
              "192.168.12.139/16",
              "fe80::20c:29ff:feca:6776/64"
            ]
          },
          "lo": {
-           "Name": "lo",
-           "Index": 1,
-           "HardwareAddr": "",
-           "IpAddresses": [
+           "name": "lo",
+           "index": 1,
+           "hardwareAddr": "",
+           "ipAddresses": [
              "127.0.0.1/8",
              "::1/128"
            ]
          }
        }
      },
-     "Kernel": {
-       "Name": "Linux",
-       "Release": "3.19.0-031900rc6-generic",
-       "Version": "#201501261152 SMP Mon Jan 26 16:53:27 UTC 2015"
+     "kernel": {
+       "name": "Linux",
+       "release": "3.19.0-031900rc6-generic",
+       "version": "#201501261152 SMP Mon Jan 26 16:53:27 UTC 2015"
      },
-     "MachineID": "3ca6d0646855f7cc6480630a54ac4a20",
-     "Memory": {
-       "Total": 1024004096,
-       "Free": 727904256,
-       "Shared": 684032,
-       "Buffered": 24641536
+     "machineID": "3ca6d0646855f7cc6480630a54ac4a20",
+     "memory": {
+       "total": 1024004096,
+       "free": 727904256,
+       "shared": 684032,
+       "buffered": 24641536
      },
-     "OSRelease": {
-       "Name": "Ubuntu",
-       "ID": "ubuntu",
-       "PrettyName": "Ubuntu 14.10",
-       "Version": "14.10 (Utopic Unicorn)",
-       "VersionID": "14.10"
+     "osRelease": {
+       "name": "Ubuntu",
+       "id": "ubuntu",
+       "prettyName": "Ubuntu 14.10",
+       "version": "14.10 (Utopic Unicorn)",
+       "versionID": "14.10"
      },
-     "Swap": {
-       "Total": 4294963200,
-       "Free": 4294963200
+     "swap": {
+       "total": 4294963200,
+       "free": 4294963200
      },
-     "Uptime": 12673
+     "uptime": 12673
    }
 }
 ```

--- a/facts.go
+++ b/facts.go
@@ -19,69 +19,69 @@ import (
 
 // SystemFacts holds the system facts.
 type SystemFacts struct {
-	Architecture string
-	BootID       string
-	Date         Date
-	Domainname   string
-	Hostname     string
-	Network      Network
-	Kernel       Kernel
-	MachineID    string
-	Memory       Memory
-	OSRelease    OSRelease
-	Swap         Swap
-	Uptime       int64
-	LoadAverage  LoadAverage
+	Architecture string      `json:"architecture"`
+	BootID       string      `json:"bootID"`
+	Date         Date        `json:"date"`
+	Domainname   string      `json:"domainName"`
+	Hostname     string      `json:"hostName"`
+	Network      Network     `json:"network"`
+	Kernel       Kernel      `json:"kernel"`
+	MachineID    string      `json:"machineID"`
+	Memory       Memory      `json:"memory"`
+	OSRelease    OSRelease   `json:"osRelease"`
+	Swap         Swap        `json:"swap"`
+	Uptime       int64       `json:"uptime"`
+	LoadAverage  LoadAverage `json:"loadAverage"`
 
 	mu sync.Mutex
 }
 
 // Holds the load average facts.
 type LoadAverage struct {
-	One  uint64
-	Five uint64
-	Ten  uint64
+	One  uint64 `json:"one"`
+	Five uint64 `json:"five"`
+	Ten  uint64 `json:"ten"`
 }
 
 // Date holds the date facts.
 type Date struct {
-	Unix int64
-	UTC  string
+	Unix int64  `json:"unix"`
+	UTC  string `json:"UTC"`
 }
 
 // Swap holds the swap facts.
 type Swap struct {
-	Total uint64
-	Free  uint64
+	Total uint64 `json:"total"`
+	Free  uint64 `json:"free"`
 }
 
 // OSRelease holds the OS release facts.
 type OSRelease struct {
-	Name       string
-	ID         string
-	PrettyName string
-	Version    string
-	VersionID  string
+	Name       string `json:"name"`
+	ID         string `json:"id"`
+	PrettyName string `json:"prettyName"`
+	Version    string `json:"version"`
+	VersionID  string `json:"versionID"`
 }
 
 // Kernel holds the kernel facts.
 type Kernel struct {
-	Name    string
-	Release string
-	Version string
+	Name    string `json:"name"`
+	Release string `json:"release"`
+	Version string `json:"version"`
 }
 
 // Memory holds the memory facts.
 type Memory struct {
-	Total    uint64
-	Free     uint64
-	Shared   uint64
-	Buffered uint64
+	Total    uint64 `json:"total"`
+	Free     uint64 `json:"free"`
+	Shared   uint64 `json:"shared"`
+	Buffered uint64 `json:"buffered"`
 }
 
 // Network holds the network facts.
 type Network struct {
-	Interfaces Interfaces
+	Interfaces Interfaces `json:"interfaces"`
 }
 
 // Interfaces holds the interface facts.
@@ -89,10 +89,10 @@ type Interfaces map[string]Interface
 
 // Interface holds facts for a single interface.
 type Interface struct {
-	Name         string
-	Index        int
-	HardwareAddr string
-	IpAddresses  []string
+	Name         string   `json:"name"`
+	Index        int      `json:"index"`
+	HardwareAddr string   `json:"hardwareAddr"`
+	IpAddresses  []string `json:"ipAddresses"`
 }
 
 func getFacts() *facts.Facts {


### PR DESCRIPTION
Explicitly define the key names in the JSON output.

There was some conversation on Twitter about this. I suggest it would be
good to make explicit choices about key names and avoid letting Go defaults
leak into the serialisation format.
