### PR TITLE
Specify Fact in argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@ Terminus ships with a default set of facts that represent info about the system.
 ### Print a single fact
 
 ```
-terminus --format '{{.System.BootID}}'
+$ terminus --format '{{.System.BootID}}'
+029b978a8d0b4ac48c5ca9c92956eeb6
 ```
 
+or
+
 ```
+$ terminus .System.BootID
 029b978a8d0b4ac48c5ca9c92956eeb6
 ```
 

--- a/main.go
+++ b/main.go
@@ -47,6 +47,13 @@ func main() {
 
 	f := getFacts()
 
+	// If there are any flags left over, use the first as a fact request
+	// and create a "format" out of it.
+	if len(flag.Args()) > 0 {
+		args := flag.Args()
+		format = fmt.Sprintf("{{%s}}", args[0])
+	}
+
 	if format != "" {
 		tmpl, err := template.New("format").Parse(format)
 		if err != nil {


### PR DESCRIPTION
This commit enables the ability to specify a fact on the command-line without
the need to format it.
