### PR TITLE
Only Print to stderr in Debug Mode

### DIFF
--- a/facts.go
+++ b/facts.go
@@ -167,7 +167,9 @@ func (f *SystemFacts) getSysInfo(wg *sync.WaitGroup) {
 
 	var info unix.Sysinfo_t
 	if err := unix.Sysinfo(&info); err != nil {
-		log.Println(err.Error())
+		if debug {
+			log.Println(err.Error())
+		}
 		return
 	}
 
@@ -195,7 +197,9 @@ func (f *SystemFacts) getOSRelease(wg *sync.WaitGroup) {
 	defer wg.Done()
 	osReleaseFile, err := os.Open("/etc/os-release")
 	if err != nil {
-		log.Println(err.Error())
+		if debug {
+			log.Println(err.Error())
+		}
 		return
 	}
 	defer osReleaseFile.Close()
@@ -229,13 +233,17 @@ func (f *SystemFacts) getMachineID(wg *sync.WaitGroup) {
 	defer wg.Done()
 	machineIDFile, err := os.Open("/etc/machine-id")
 	if err != nil {
-		log.Println(err.Error())
+		if debug {
+			log.Println(err.Error())
+		}
 		return
 	}
 	defer machineIDFile.Close()
 	data, err := ioutil.ReadAll(machineIDFile)
 	if err != nil {
-		log.Println(err.Error())
+		if debug {
+			log.Println(err.Error())
+		}
 		return
 	}
 
@@ -250,13 +258,17 @@ func (f *SystemFacts) getBootID(wg *sync.WaitGroup) {
 	defer wg.Done()
 	bootIDFile, err := os.Open("/proc/sys/kernel/random/boot_id")
 	if err != nil {
-		log.Println(err.Error())
+		if debug {
+			log.Println(err.Error())
+		}
 		return
 	}
 	defer bootIDFile.Close()
 	data, err := ioutil.ReadAll(bootIDFile)
 	if err != nil {
-		log.Println(err.Error())
+		if debug {
+			log.Println(err.Error())
+		}
 		return
 	}
 
@@ -271,7 +283,9 @@ func (f *SystemFacts) getInterfaces(wg *sync.WaitGroup) {
 	defer wg.Done()
 	ls, err := net.Interfaces()
 	if err != nil {
-		log.Println(err.Error())
+		if debug {
+			log.Println(err.Error())
+		}
 		return
 	}
 
@@ -286,7 +300,9 @@ func (f *SystemFacts) getInterfaces(wg *sync.WaitGroup) {
 
 		addrs, err := i.Addrs()
 		if err != nil {
-			log.Println(err.Error())
+			if debug {
+				log.Println(err.Error())
+			}
 			return
 		}
 		for _, ip := range addrs {
@@ -325,7 +341,9 @@ func (f *SystemFacts) getUname(wg *sync.WaitGroup) {
 	var buf unix.Utsname
 	err := unix.Uname(&buf)
 	if err != nil {
-		log.Println(err.Error())
+		if debug {
+			log.Println(err.Error())
+		}
 		return
 	}
 
@@ -346,7 +364,9 @@ func (f *SystemFacts) getFileSystems(wg *sync.WaitGroup) {
 
 	mtab, err := ioutil.ReadFile("/etc/mtab")
 	if err != nil {
-		log.Println(err.Error())
+		if debug {
+			log.Println(err.Error())
+		}
 		return
 	}
 
@@ -369,14 +389,18 @@ func (f *SystemFacts) getFileSystems(wg *sync.WaitGroup) {
 		fs.Options = strings.Split(fields[3], ",")
 		dumpFreq, err := strconv.ParseUint(fields[4], 10, 64)
 		if err != nil {
-			log.Println(err.Error())
+			if debug {
+				log.Println(err.Error())
+			}
 			return
 		}
 		fs.DumpFreq = dumpFreq
 
 		passNo, err := strconv.ParseUint(fields[4], 10, 64)
 		if err != nil {
-			log.Println(err.Error())
+			if debug {
+				log.Println(err.Error())
+			}
 			return
 		}
 		fs.PassNo = passNo
@@ -391,14 +415,18 @@ func (f *SystemFacts) getFileSystems(wg *sync.WaitGroup) {
 func processExternalFacts(dir string, f *facts.Facts) {
 	d, err := os.Open(dir)
 	if err != nil {
-		log.Println(err)
+		if debug {
+			log.Println(err)
+		}
 		return
 	}
 	defer d.Close()
 
 	files, err := d.Readdir(0)
 	if err != nil {
-		log.Println(err)
+		if debug {
+			log.Println(err)
+		}
 		return
 	}
 
@@ -434,13 +462,17 @@ func factsFromFile(path string, f *facts.Facts, wg *sync.WaitGroup) {
 	defer wg.Done()
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		log.Println(err)
+		if debug {
+			log.Println(err)
+		}
 		return
 	}
 	var result interface{}
 	err = json.Unmarshal(data, &result)
 	if err != nil {
-		log.Println(err)
+		if debug {
+			log.Println(err)
+		}
 		return
 	}
 	f.Add(strings.TrimSuffix(filepath.Base(path), ".json"), result)
@@ -450,13 +482,17 @@ func factsFromExec(path string, f *facts.Facts, wg *sync.WaitGroup) {
 	defer wg.Done()
 	out, err := exec.Command(path).Output()
 	if err != nil {
-		log.Println(err)
+		if debug {
+			log.Println(err)
+		}
 		return
 	}
 	var result interface{}
 	err = json.Unmarshal(out, &result)
 	if err != nil {
-		log.Println(err)
+		if debug {
+			log.Println(err)
+		}
 		return
 	}
 	f.Add(filepath.Base(path), result)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var (
 	formatFile       string
 	httpAddr         string
 	printVersion     bool
+	debug            bool
 )
 
 func init() {
@@ -28,6 +29,7 @@ func init() {
 	flag.StringVar(&formatFile, "format-file", "", "Format the output using the given go template file.")
 	flag.StringVar(&httpAddr, "http", "", "HTTP service address (e.g., ':6060')")
 	flag.BoolVar(&printVersion, "version", false, "print version and exit")
+	flag.BoolVar(&debug, "debug", false, "print errors to stderr instead of ignoring them")
 }
 
 var defaultExternalFacts = "/etc/terminus/facts.d"


### PR DESCRIPTION
This commit omits error messages unless Terminus is run with --debug. This
should make for cleaner output but at the expense of possible confusion as to
why a fact was not printed.
