### PR TITLE
Query for Fact Through argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ Terminus ships with a default set of facts that represent info about the system.
 ### Print a single fact
 
 ```
-terminus --format '{{.System.BootID}}'
+$ terminus --format '{{.System.BootID}}'
+029b978a8d0b4ac48c5ca9c92956eeb6
 ```
 
+or
+
 ```
-029b978a8d0b4ac48c5ca9c92956eeb6
+$ terminus System.Network.Interfaces.eth0.Ip6Addresses.0.Ip
+fe80::f816:3eff:fead:8549
 ```
 
 ### Print all facts


### PR DESCRIPTION
This commit adds the ability to query for a fact with a command-line argument.
The format of the query is the path to the fact separated by .'s. Arrays of
facts can have their numerical index specified.
